### PR TITLE
fixing custom footprint to be converted to array

### DIFF
--- a/scipy_algorithm_baseclasses.py
+++ b/scipy_algorithm_baseclasses.py
@@ -906,8 +906,9 @@ class SciPyStatisticalAlgorithm(SciPyAlgorithmWithMode):
 
         footprint = self.parameterAsString(parameters, self.FOOTPRINT, context)
         if footprint:
-            kwargs['footprint'] = str_to_array(footprint, self._ndim)
-            sizelist = sizelist.extend(footprint.shape)
+            footprint = str_to_array(footprint, self._ndim) #converting footprint from str to array
+            kwargs['footprint'] = footprint
+            sizelist.extend(footprint.shape) #list is updated with the footprint shape
 
 
         origin = self.parameterAsString(parameters, self.ORIGIN, context)


### PR DESCRIPTION
Hi! I've encountered an error when trying to pass a custom footprint for Maximum/Minimum Filter. I think the problem was in `get_parameters()`. When `kwargs['footprint']` is assigned with `str_to_array(footprint, self._ndim)`, the footprint itself is not converted to `np.array`. This causes `AttributeError: 'str' object has no attribute 'shape'` when `sizelist `needs to be extended with footprint size. Checked in QGIS 3.42.1